### PR TITLE
Export an operation that looks update up on the context

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "effection": "^3.0.1",
+    "effection": "^3.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "spinners-react": "1.0.7"

--- a/src/hooks/useLoader.ts
+++ b/src/hooks/useLoader.ts
@@ -1,7 +1,7 @@
 import { useMemo, useEffect, useState, useCallback } from "react";
-import { run, type Callable } from "effection";
+import { run, type Callable, lift } from "effection";
 import { CreateLoaderOptions, createLoader } from "../operations/createLoader";
-import { UpdateFn, UpdateFnContext } from "../operations/UpdateFnContext";
+import { UpdateContext } from "../operations/UpdateContext";
 
 export type LoaderState<T> =
   | {
@@ -85,7 +85,7 @@ export function useLoader<T>(
 
   useEffect(() => {
     const task = run(function* () {
-      yield* UpdateFnContext.set(setState as UpdateFn);
+      yield* UpdateContext.set(lift(setState));
       yield* loader();
     });
 

--- a/src/operations/UpdateContext.ts
+++ b/src/operations/UpdateContext.ts
@@ -1,0 +1,11 @@
+import { Operation, createContext } from "effection";
+import { LoaderState } from "../hooks/useLoader";
+
+type Update = (state: LoaderState<any>) => Operation<void>;
+
+export const UpdateContext = createContext<Update>("update");
+
+export function* update<T>(state: LoaderState<T>): Operation<void> {
+  let setState = yield* UpdateContext;
+  yield* setState(state);
+}

--- a/src/operations/UpdateFnContext.ts
+++ b/src/operations/UpdateFnContext.ts
@@ -1,6 +1,0 @@
-import { createContext } from "effection";
-import { LoaderState } from "../hooks/useLoader";
-
-export type UpdateFn = (state: LoaderState<unknown>) => void;
-
-export const UpdateFnContext = createContext<UpdateFn>("updateFn");

--- a/src/operations/createLoader.ts
+++ b/src/operations/createLoader.ts
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import { Operation, sleep, spawn, call, useAbortSignal } from "effection";
 import { CreateSpinnerOptions, createSpinner } from "./createSpinner";
-import { UpdateFnContext } from "./UpdateFnContext";
+import { update } from "./UpdateContext";
 import { LoaderFn } from "../hooks/useLoader";
 
 export type CreateLoaderOptions<T> = {
@@ -21,9 +21,7 @@ export function createLoader<T>({
   retryingMessageInterval,
 }: CreateLoaderOptions<T>): () => Operation<void> {
   return function* loader() {
-    const update = yield* UpdateFnContext;
-
-    update({
+    yield* update({
       type: "started",
     });
 
@@ -41,7 +39,7 @@ export function createLoader<T>({
       try {
         const result = yield* call(() => load({ attempt, signal }));
 
-        update({
+        yield* update({
           type: "success",
           value: result,
         });
@@ -53,17 +51,17 @@ export function createLoader<T>({
         const error = e instanceof Error ? e : new Error(`${e}`);
 
         if (attempt + 1 === retryAttempts) {
-          update({
+          yield* update({
             type: "failed",
             error,
           });
         } else {
-          update({
+          yield* update({
             type: "failed-attempt",
             error,
           });
           yield* sleep(failedAttemptErrorInterval);
-          update({
+          yield* update({
             type: "retrying",
             error,
           });

--- a/src/operations/createSpinner.ts
+++ b/src/operations/createSpinner.ts
@@ -1,5 +1,5 @@
 import { Operation, sleep } from "effection";
-import { UpdateFnContext } from "./UpdateFnContext";
+import { update } from "./UpdateContext";
 
 export type CreateSpinnerOptions = {
   showSpinnerAfterInterval: number;
@@ -13,20 +13,18 @@ export function createSpinner({
   loadingSlowlyInterval,
 }: CreateSpinnerOptions) {
   return function* loadingSpinner(): Operation<void> {
-    const update = yield* UpdateFnContext;
-
     yield* sleep(showSpinnerAfterInterval);
 
     let count = 0;
     while (true) {
-      update({
+      yield* update({
         type: "loading",
         count,
       });
 
       yield* sleep(loadingInterval);
 
-      update({
+      yield* update({
         type: "loading-slowly",
       });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -922,10 +922,10 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-effection@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/effection/-/effection-3.0.1.tgz#4f6fdfae5091f4ca0d446050235654ecb160b021"
-  integrity sha512-NAGvwkKmIHx24kngeAFl0mT0h507mNluGCkW+dQBSsCP0H8RfZeA/aIuEbMl7WcQL0AoPxY6LYQlW/SmGhth3A==
+effection@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/effection/-/effection-3.0.2.tgz#1a4a9c2441e6435d557ad765c60b2690dfd334c2"
+  integrity sha512-TTcH8f6vrD5JpRGJFi8x3HN7qa0v6DqoMcuc0EYDEClkqq9mMIR3lx6dHZ8I9ADP6B56VcpQ27dGD75kko2Vbg==
 
 electron-to-chromium@^1.4.601:
   version "1.4.610"


### PR DESCRIPTION
## Motivation

Rather than make updating state a two step process of first get the update function, then invoke it, just couple to a single step: a general `update()` operation.


## Approach

Export an `update()` operation that does the lookup of the setState for you, and then invokes it. That way, you just say:

```js
yield* update(state);
```

from anywhere in one step. If the context is missing, it will complain about it. This is the more general pattern of contextual
effects.

At the same time, this "lifts" the raw `setState()` function into an operation which is safer. In general, any function that could potentially cause your operation to exit should be lifted into an operation itself. That way, let's say you call `setState()` and it causes your component to be torn down, which then halts your effect, then you don't want anything to run after that in your operation.