### PR TITLE
Do not delay showing loading spinner on retry attempts and make update the lifted operation

### DIFF
--- a/src/hooks/useLoader.ts
+++ b/src/hooks/useLoader.ts
@@ -23,6 +23,7 @@ export type LoaderState<T> =
     }
   | {
       type: "failed-attempt";
+      attempt: number;
       error: Error;
     }
   | {

--- a/src/hooks/useLoader.ts
+++ b/src/hooks/useLoader.ts
@@ -1,7 +1,7 @@
 import { useMemo, useEffect, useState, useCallback } from "react";
 import { run, type Callable } from "effection";
 import { CreateLoaderOptions, createLoader } from "../operations/createLoader";
-import { setUpdate } from "../operations/UpdateContext";
+import { setUpdateContext, update } from "../operations/UpdateContext";
 
 export type LoaderState<T> =
   | {
@@ -86,14 +86,13 @@ export function useLoader<T>(
 
   useEffect(() => {
     const task = run(function* () {
-      const update = yield* setUpdate(setState);
+      yield* setUpdateContext(setState);
       yield* update({ type: "initial" })
       yield* loader();
     });
 
     return () => {
       run(() => task.halt());
-
     };
   }, [loader, key]);
 

--- a/src/operations/UpdateContext.ts
+++ b/src/operations/UpdateContext.ts
@@ -1,16 +1,14 @@
 import { Operation, createContext, lift } from "effection";
 import { LoaderState } from "../hooks/useLoader";
 
-type Update<T> = (state: LoaderState<T>) => Operation<void>;
+export const UpdateContext = createContext<typeof update>("update");
 
-export const UpdateContext = createContext<Update<unknown>>("update");
-
-export const update: Update<unknown> = function* update(value) {
+export const update = function* update<T>(value: LoaderState<T>): Operation<void> {
   const setState = yield* UpdateContext;
   yield* setState(value);
 }
 
-export function* setUpdate(setState: (value: LoaderState<unknown>) => void): Operation<Update<unknown>> {
+export function* setUpdate(setState: (value: LoaderState<unknown>) => void): Operation<typeof update> {
   const lifted = lift(setState);
   yield* UpdateContext.set(lifted);
   return lifted;

--- a/src/operations/UpdateContext.ts
+++ b/src/operations/UpdateContext.ts
@@ -1,11 +1,17 @@
-import { Operation, createContext } from "effection";
+import { Operation, createContext, lift } from "effection";
 import { LoaderState } from "../hooks/useLoader";
 
-type Update = (state: LoaderState<any>) => Operation<void>;
+type Update<T> = (state: LoaderState<T>) => Operation<void>;
 
-export const UpdateContext = createContext<Update>("update");
+export const UpdateContext = createContext<Update<unknown>>("update");
 
-export function* update<T>(state: LoaderState<T>): Operation<void> {
-  let setState = yield* UpdateContext;
-  yield* setState(state);
+export const update: Update<unknown> = function* update(value) {
+  const setState = yield* UpdateContext;
+  yield* setState(value);
+}
+
+export function* setUpdate(setState: (value: LoaderState<unknown>) => void): Operation<Update<unknown>> {
+  const lifted = lift(setState);
+  yield* UpdateContext.set(lifted);
+  return lifted;
 }

--- a/src/operations/UpdateContext.ts
+++ b/src/operations/UpdateContext.ts
@@ -8,8 +8,6 @@ export const update = function* update<T>(value: LoaderState<T>): Operation<void
   yield* setState(value);
 }
 
-export function* setUpdate(setState: (value: LoaderState<unknown>) => void): Operation<typeof update> {
-  const lifted = lift(setState);
-  yield* UpdateContext.set(lifted);
-  return lifted;
+export function* setUpdateContext(setState: (value: LoaderState<unknown>) => void): Operation<void> {
+  yield* UpdateContext.set(lift(setState));
 }

--- a/src/operations/createSpinner.ts
+++ b/src/operations/createSpinner.ts
@@ -2,19 +2,15 @@ import { Operation, sleep } from "effection";
 import { update } from "./UpdateContext";
 
 export type CreateSpinnerOptions = {
-  showSpinnerAfterInterval: number;
   loadingInterval: number;
   loadingSlowlyInterval: number;
 };
 
 export function createSpinner({
-  showSpinnerAfterInterval,
   loadingInterval,
   loadingSlowlyInterval,
 }: CreateSpinnerOptions) {
   return function* loadingSpinner(): Operation<void> {
-    yield* sleep(showSpinnerAfterInterval);
-
     let count = 0;
     while (true) {
       yield* update({


### PR DESCRIPTION
## Motivation

I was showing a developer how to use this loading spinner and it made me realize that the retry mechanism and initial load are unnecessarily coupled. This caused the loading spinner to be delayed between retries. 

## Approach

1. Moved `showSpinnerAfterInterval` out of spinner
2. Calling `sleep(showSpinnerAfterInterval)` before starting loading spinner only the first time
4. Created `setUpdate` function
5. Invoke retry logic in `catch` after the initial try. 