### PR TITLE
Added a way to stop the operation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import "./App.css";
-import { sleep, Operation } from "effection";
+import { sleep, Operation, run } from "effection";
 import { Player } from "./components/Player";
 import { useState } from "react";
 
@@ -170,6 +170,21 @@ export const App = () => {
                   }
                 }
               }
+            }}
+            {...options}
+          />
+        </li>
+        <li key="7" className="p-5">
+          <Player
+            title="Can be stopped when encountering a specific problem"
+            description="Show a loading spinner after 1 minute then show a message that connect because of VPN connection"
+            load={async function ({ stop }) {
+              await run(function* () {
+                yield* sleep(4000);
+                yield* stop("Not connected to the VPN.");
+              });
+
+              return "Will never happen"
             }}
             {...options}
           />

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -39,6 +39,12 @@ export function LoadingSpinner({ loader }: { loader: LoaderState<unknown> }): JS
           Failed after 3 attempts. Please contact support.
         </p>
       )
+    case "stopped":
+      return (
+        <p className="text-sky-400">
+          {loader.reason}
+        </p>
+      )
   }
 
   return <></>


### PR DESCRIPTION
## Motivation

I want to be able to stop the loader when encountering an error. This is useful when encountering a "VPN not connected" situation. In this case, I want to stop the operation and not have it do anything else. 

## Approach

1. Added a new state type called "stopped"
2. Added check for "stopped" in the update function that runs `suspend`
3. Refactored to use channels to allow interrupting the loading driver when encountering a stopped state

### TODOs and Open Questions

- [ ] Add the ability to resume when the connection is restored
